### PR TITLE
Update WpProQuiz_Helper_DbUpgrade.php

### DIFF
--- a/lib/helper/WpProQuiz_Helper_DbUpgrade.php
+++ b/lib/helper/WpProQuiz_Helper_DbUpgrade.php
@@ -113,7 +113,7 @@ class WpProQuiz_Helper_DbUpgrade {
 			  `show_points_in_box` tinyint(1) NOT NULL,
 			  `answer_points_activated` tinyint(1) NOT NULL,
 			  `answer_data` longtext NOT NULL,
-			  `category_id` int(10) unsigned NOT NULL,,
+			  `category_id` int(10) unsigned NOT NULL,
 			  `matrix_sort_answer_criteria_width` int(10) unsigned NOT NULL,
 			  PRIMARY KEY (`id`),
 			  KEY `quiz_id` (`quiz_id`),


### PR DESCRIPTION
MySQL Error:

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' `matrix_sort_answer_criteria_width` int(10) unsigned NOT NULL, PRIM' at line 17
